### PR TITLE
Dev/add create button

### DIFF
--- a/src/app/board/columns/issue_columns.tpl.html
+++ b/src/app/board/columns/issue_columns.tpl.html
@@ -14,6 +14,10 @@
 
       <h1 class="column-header">{{colCtrl.columnName}}</h1>
 
+      <a class="btn btn-success"
+         ng-href="https://github.com/{{repoDetails.owner}}/{{repoDetails.repo}}/issues/new"
+         target="_blank">Create Issue</a>
+
       <!-- CARDS List -->
       <ul class="column-body" ui-sortable="colCtrl.sortableOptions"
                               ng-model="colCtrl.issues" >

--- a/src/app/board/main/main.js
+++ b/src/app/board/main/main.js
@@ -5,6 +5,12 @@ angular.module('GitKan.board')
 
    var ctrl = this;
 
+   // Expose repo details so we can use them in the markup
+   $scope.repoDetails = {
+      owner : $stateParams.owner,
+      repo  : $stateParams.repo
+   };
+
    function setConfiguration(conf) {
       $scope.config = conf;
    }


### PR DESCRIPTION
This is a simple change to add a link button to open the new issue dialog on github.

The other option I considered was to open the new issue page in an iframe in a dialog.  This would let people feel like they are staying in the app, but not sure if it is needed.  This is enough to get an MVP up and working.
