### PR TITLE
Dev/add user logout

### DIFF
--- a/src/app/app.js
+++ b/src/app/app.js
@@ -4,6 +4,7 @@ angular.module( 'Trestle', [
    'Trestle.board',
    'Trestle.login',
    'Trestle.issue',
+   'Trestle.authentication',
    'github.api',
    'ui.sortable',
    'ui.bootstrap',

--- a/src/app/repos_ctrl.js
+++ b/src/app/repos_ctrl.js
@@ -1,11 +1,19 @@
 angular.module('Trestle')
 
-.controller( 'ReposCtrl', function($scope, $stateParams, $location, trRepoModel) {
+.controller( 'ReposCtrl', function($scope, $stateParams, $location, gh, auth, trRepoModel) {
    $scope.$id = "ResposCtrl_" + $scope.$id;
 
    this.init = function() {
       // Put the repo model into the scope so that templates can access it
       $scope.repoModel = trRepoModel;
+
+      // Because this controller could be loaded right away, without going through
+      // the login page, we must see if the user has a valid session.
+      var token = auth.getAuthToken();
+      if (!token) {
+         $location.path('/login');
+      }
+      gh.setAccessToken(token);
 
       // Update configuration for repository service
       // Reload repository service (if needed)

--- a/src/app/services/auth_service.js
+++ b/src/app/services/auth_service.js
@@ -1,0 +1,193 @@
+/**
+ @ngdoc overview
+ @name  Trestle.authentication
+
+ @description
+ Holds services, controllers, etc related to authenticating users with the system.
+ */
+angular.module('Trestle.authentication', [])
+
+/**
+ @ngdoc service
+ @name  Trestle.authentication.auth
+
+ @description
+ Provides tools for logging in and out of the system and presisting the
+ authentication across browser refreshes.
+ */
+.service('auth', function($http) {
+   var
+   // The key to store session tokens under when using storage
+   storage_key = 'trestle-gh-token',
+   // Magic string we use to mark a GitHub authentication as ours.
+   // This allows the user to be revoke authentication later on.
+   auth_key    = 'trestle',
+   // The current session token or null if there is no token
+   token = null;
+
+   // See if there was a token before so that the user can stay logged in
+   // across sessions.
+   token = localStorage ? localStorage.getItem(storage_key) : null;
+   if ( !token ) {
+      token = sessionStorage ? sessionStorage.getItem(storage_key) : null;
+   }
+
+   /**
+    @ngdoc    function
+    @name     setAuthToken
+    @methodOf Trestle.authentication.auth
+    @private
+
+    @description
+    Sets the active token and stores it in local or session storage depeneding
+    on if the user wants the computer to remember them.
+
+    Use `login` and `logout` to manipulate the token.
+
+    @param {String}  newToken   The new token
+    @param {boolean} rememberMe Flag indicating if the user trusts this computer
+           and wants it to store the session token locally so that they do not
+           need to login again.
+    */
+   function setAuthToken(newToken, rememberMe) {
+      // Update in memory copy
+      token = newToken;
+
+      // Set the value into storage if the user wants future sessions to
+      // be authenticated.
+      if (rememberMe && localStorage) {
+         localStorage.setItem(storage_key, token);
+      }
+      else if (window.sessionStorage) {
+         sessionStorage.setItem(storage_key, token);
+      }
+   }
+
+   /**
+    @ngdoc    function
+    @name     getAuthToken
+    @methodOf Trestle.authentication.auth
+
+    @description
+    Provides access to the current token.
+
+    @returns {String|null} The current token or null if none is set
+    */
+   this.getAuthToken = function() {
+      return token;
+   };
+
+   /**
+    @ngdoc    function
+    @name     logout
+    @methodOf Trestle.authentication.auth
+
+    @description
+    Logs the user out of the system and clears the stored token so that
+    reloading the page does not automatically log them back in.
+    */
+   this.logout = function() {
+      // Clear the in memory version
+      token = null;
+
+      // Clear both of the storages
+      _.each([localStorage, sessionStorage], function(storage) {
+         storage.removeItem(storage_key);
+      });
+   };
+
+   /**
+    @ngdoc    function
+    @name     login
+    @methodOf Trestle.authentication.auth
+
+    @description
+    Attempts to log the user in to GitHub and if successful then returns the auth
+    token from GitHub.
+
+    This uses basic authentication instead of OAUTH because we do not have a
+    secure location to store the OAUTH secret for the Trestle application.  To
+    work around this we the provided credentials create a token we can use and
+    then store it in GitHub so that the user can revoke the authentication
+    later on.
+
+    @returns {Promise} The success chain will be fired with the users token if
+             they provided credentials were correct.
+    */
+   this.login = function(username, password, rememberMe) {
+      // Query GitHub to see if the creds were valid
+      var p = $http({
+         method: 'GET',
+         url:    'https://api.github.com/authorizations',
+         headers: {
+            Authorization: 'Basic ' + window.btoa(username + ':' + password)
+         }
+      });
+
+      // On success store the token for later use
+      // Otherwise, return an error
+      p.then(angular.bind(this, this._onLoginSuccess, !!rememberMe),
+             angular.bind(this, this._onLoginError));
+
+      // The users of the this promise will not be called until after our
+      // callbacks are finished.
+      return p;
+   };
+
+   /**
+    @ngdoc    function
+    @name     _onLoginSuccess
+    @methodOf Trestle.authentication.auth
+
+    @description
+    Called when the user provides valid credentials to the `login` method with
+    the HTTP response.
+
+    Looks through the users existing authorizations to see if Trestle is
+    already authorized.  If so that we use its token.  If this is the first time
+    Trestle has logged in then a new authorization is created and that token is
+    returned.
+
+    The new token is also cached in memory and storage so that the user does not
+    need to log in again later (if they do not want to).
+
+    @param {boolean} rememberMe Flag indicating if the token aquired from GitHub
+           should be cached locally.
+    @param {object} res The HTTP response from GitHub.  see HttpPromise in
+           angular docs.
+
+    @returns {String|Promise} The token to use
+    */
+   this._onLoginSuccess = function(rememberMe, res) {
+      var auths = res.data;
+      // See if any of the authorizations are for our app
+      var auth = _.find(auths, function(auth) {
+         return auth.note === auth_key;
+      });
+
+      // Yeah, the user already had a token for us
+      if (auth) {
+         // Some stuff
+         setAuthToken(auth.token, rememberMe);
+         // Return the new token in case people need to use it.
+         return token;
+      }
+
+      // The user did not have a token for us so we must make one and store it
+      // for later use.
+      if (1) {
+         throw new Error('adsf');
+      }
+
+      // XXX Add the authorization ourselves
+
+      return token;
+   };
+
+   this._onLoginError = function(res) {
+      console.warn('login error');
+   };
+
+})
+
+;

--- a/src/app/toolbar/toolbar.js
+++ b/src/app/toolbar/toolbar.js
@@ -1,18 +1,92 @@
 angular.module('Trestle.board')
 
+
+/**
+ @ngdoc function
+ @name  Trestle.board.ToolbarCtrl
+
+ @description
+ Provides the tools for handling the toolbar
+ */
 .controller('ToolbarCtrl', function($location, $stateParams, $dialog, gh) {
-   var me = this;
+   /**
+    @ngdoc    method
+    @name     init
+    @methodOf Trestle.board.ToolbarCtrl
 
-   gh.listAllRepos($stateParams.owner, $stateParams.repo).then(function(allRepos) {
-      // Build up a tree of the issues to make things easier to search through
-      me.allRepos = _.groupBy(allRepos, function(repo) {
-         return repo.owner.login;
+    @description
+    Initializes the controller.
+
+    XXX look at moving this to the show method
+    */
+   this.init = function() {
+      var me = this;
+
+      gh.listAllRepos($stateParams.owner, $stateParams.repo).then(function(allRepos) {
+         // Build up a tree of the issues to make things easier to search through
+         me.allRepos = _.groupBy(allRepos, function(repo) {
+            return repo.owner.login;
+         });
       });
-   });
+   };
 
+   /**
+    @ngdoc    method
+    @name     onSwitchToRepo
+    @methodOf Trestle.board.ToolbarCtrl
+
+    @description
+    Called when the user selectes a new repository to show a board for.
+    */
    this.onSwitchToRepo = function (repo) {
       console.log('switch to repo: ' + repo.full_name);
       $location.path('/repo/' + repo.full_name + '/board');
    };
+})
 
-});
+/**
+ @ngdoc    function
+ @name     Trestle.board.UserDetailsCtrl
+
+ @description
+ Provides controls for handling the users details area in the toolbar.
+ Currently, this provides the ability to logout.
+ */
+.controller('UserDetailsCtrl', function($location, auth, gh) {
+
+   /**
+    @ngdoc    method
+    @name     init
+    @methodOf Trestle.board.UserDetailsCtrl
+
+    @description
+    Initializes the controller.
+    */
+   this.init = function() {
+      // Get the users details (avatar, name, ...)
+      // - This a `Promise` that when resolved will update the toolbar
+      this.user = gh.getUserDetails();
+   };
+
+   /**
+    @ngdoc    method
+    @name     onLogout
+    @methodOf Trestle.board.UserDetailsCtrl
+
+    @description
+    Called when the user selects the logout button.  This will clear the cached
+    session and redirect the user to the login page.
+    */
+   this.onLogout = function() {
+      // Remove the users access token
+      auth.logout();
+
+      // Clear the gh token
+      gh.setAccessToken(null);
+
+      // Send us back to the login page
+      $location.path('/login');
+   };
+})
+
+;

--- a/src/app/toolbar/toolbar.scss
+++ b/src/app/toolbar/toolbar.scss
@@ -3,7 +3,7 @@
         height: 1em;
     }
 
-    .dropdown-menu {
+    #repo-list {
         width: 400px;
 
         .filter {
@@ -25,5 +25,11 @@
     #issue-search {
         width: 20em;
         margin: 5px;
+    }
+
+    #settings {
+        // Reduce the padding of the settings area to allow the avatar to have
+        // enough space
+        padding: 5px;
     }
 }

--- a/src/app/toolbar/toolbar.tpl.html
+++ b/src/app/toolbar/toolbar.tpl.html
@@ -1,4 +1,7 @@
-<div class="board-toolbar navbar" ng-controller="ToolbarCtrl as toolbarCtrl" >
+<div class="board-toolbar navbar"
+     ng-controller="ToolbarCtrl as toolbarCtrl"
+     ng-init="toolbarCtrl.init()">
+
   <div class="navbar-inner">
     <a class="brand" id="github-link" ng-href="http://github.com/{{repoModel.getFullRepoName()}}" target="_blank" >
       <img src="assets/image/GitHub-Mark-64px.png"></img>
@@ -11,7 +14,7 @@
           <span ng-if="repoModel.repo" >{{repoModel.getFullRepoName()}}</span>
         </a>
 
-        <div class="dropdown-menu">
+        <div id="repo-list" class="dropdown-menu">
           <div class="filter" >
             <input type="text" placeholder="Search" ng-model="repoSearchText"
                    class="search-query" ></input>
@@ -36,15 +39,35 @@
         <input id="issue-search" type="text" placeholder="Search" class="navbar-search"
                ng-model="repoModel.cardSearchText" ></input>
       </li>
+    </ul>
 
-      <li class="pull-right">
+    <ul class="nav pull-right"
+        ng-controller="UserDetailsCtrl as userCtrl"
+        ng-init="userCtrl.init()">
+
+      <li class="dropdown" >
+        <a id="settings" class="dropdown-toggle-no-close" >
+          <img class="avatar" ng-src="{{userCtrl.user.avatar_url}}"></img>
+          {{userCtrl.user.login}}
+        </a>
+
+        <div class="dropdown-menu">
+          <span ng-click="userCtrl.onLogout()">Logout</span>
+        </div>
+      </li>
+    </ul>
+
+    <ul class="nav pull-right" >
+      <li>
         <a ng-href="#repo/{{repoModel.owner}}/{{repoModel.repo}}/milestones">Planning</a>
       </li>
 
-       <li class="pull-right">
+       <li>
         <a ng-href="#repo/{{repoModel.owner}}/{{repoModel.repo}}/board">Board</a>
       </li>
 
     </ul>
+
+  </div>
 
 </div>

--- a/src/common/github_api/github_api.spec.js
+++ b/src/common/github_api/github_api.spec.js
@@ -16,40 +16,6 @@ describe( 'GitHub API (gh)', function() {
       expect( gh.hasAccessToken() ).not.toBeTruthy();
    }));
 
-   describe( 'setAccessToken', function() {
-      it('should allow setting the key in memory only', inject( function(gh) {
-         // When the access token is set with a storage plan
-         gh.setAccessToken('my token');
-         // Then the token is available for use
-         expect( gh.hasAccessToken() ).toBeTruthy();
-         // And the token is not stored in storage
-         expect( localStorage.getItem('gh-token') ).toBeNull();
-         expect( sessionStorage.getItem('gh-token') ).toBeNull();
-      }));
-
-      it('should allow setting the key in session storage', inject(function(gh) {
-         // When the access token is set with a storage plan
-         gh.setAccessToken('my token', 'session');
-         // Then the token is available for use
-         expect( gh.hasAccessToken() ).toBeTruthy();
-         // And the token is not stored in local storage
-         expect( localStorage.getItem('gh-token') ).toBeNull();
-         // And the token should be stored in session storage
-         expect( sessionStorage.getItem('gh-token') ).toEqual('my token');
-      }));
-
-      it('should allow setting the key in local storage', inject(function(gh) {
-         // When the access token is set with a storage plan
-         gh.setAccessToken('my token', 'local');
-         // Then the token is available for use
-         expect( gh.hasAccessToken() ).toBeTruthy();
-         // And the token should not be stored in session storage
-         expect( sessionStorage.getItem('gh-token') ).toBeNull();
-         // And the token is stored in local storage
-         expect( localStorage.getItem('gh-token') ).toEqual('my token');
-      }));
-   });
-
    describe('GitHub API', function() {
       beforeEach(inject(function(gh) {
          gh.setAccessToken('sometoken');


### PR DESCRIPTION
Adds a new Auth service that handles the authentication and storage of the token (keeps the `gh` service light).

Allows users to logout

Cleans up `gh` service a bit
