### PR TITLE
Provide styling on issues that user has not looked at since last update

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -11,7 +11,8 @@
     "lodash": "~1.3.1",
     "restangular": "~1.1.3",
     "angular-ui-sortable": "~0.0.1",
-    "angular-sanitize": "~1.0.8"
+    "angular-sanitize": "~1.0.8",
+    "depot": "~0.1.6"
   },
   "dependencies": {},
   "resolutions": {

--- a/build.config.js
+++ b/build.config.js
@@ -56,7 +56,8 @@ module.exports = {
          'vendor/angular-ui-router/release/angular-ui-router.js',
          'vendor/angular-ui-utils/modules/route/route.js',
          'vendor/restangular/dist/restangular.js',
-         'vendor/angular-sanitize/angular-sanitize.js'
+         'vendor/angular-sanitize/angular-sanitize.js',
+         'vendor/depot/depot.js'
       ],
       css: [
          'vendor/bootstrap/docs/assets/css/bootstrap.css',

--- a/src/app/issue/issue.tpl.html
+++ b/src/app/issue/issue.tpl.html
@@ -1,5 +1,8 @@
-<div class="card"
+<div class="card {{issueCtrl.getBuildStatus()}}"
       ng-controller="IssueCtrl as issueCtrl"
+      ng-class="{
+        updated: issueCtrl.hasBeenUpdatedSinceLastView()
+      }"
       ng-class="issueCtrl.getBuildStatus()"
       ng-click="issueCtrl.showIssueDetails()">
    <div class="build-header"
@@ -58,7 +61,7 @@
          <!--<span class="todos"><i class="icon-check"></i>3/6</span>-->
          <span class="comments">
             <i class="icon-comments"></i>
-            {{issueCtrl.issue.tr_comments.length}}
+            {{issueCtrl.issue.comments}}
          </span>
       </div>
    </div>

--- a/src/app/issue/issues.scss
+++ b/src/app/issue/issues.scss
@@ -146,6 +146,10 @@ $avatar-size-comment : 40px;  // size of avatar on issue/pull comments
     &.pending .build-header { @include build-header-style($color-primary); }
     &.unknown .build-header { @include build-header-style;                 }
 
+  &.updated {
+    border : 4px solid blue;
+  }
+
   // Card header with title & assigned person
   .header {
     position        : relative;
@@ -515,6 +519,15 @@ $avatar-size-comment : 40px;  // size of avatar on issue/pull comments
         // Selected labels
         &.enabled {
            background     : lighten($color-grey,15);
+        }
+
+        // Small block of color for each label
+        .color-preview {
+          display         : inline-block;
+          width           : 10px;
+          height          : 10px;
+          border-radius   : 2px;
+          margin          : 0 3px;
         }
       }
     }

--- a/src/app/services/issue_cache_service.js
+++ b/src/app/services/issue_cache_service.js
@@ -1,0 +1,57 @@
+/*jshint bitwise: false*/
+
+angular.module('Trestle')
+
+/** Helper to wrap cache for information about issues.
+*/
+.service('trIssueCache', function() {
+   // We will use issue number as the id
+   var lastViewStore = depot('lastViews', {idAttribute: 'number'});
+
+   /** String hash code. */
+   function hashCode(str){
+     var hash = 0;
+     if (str.length === 0) {
+        return hash;
+     }
+     for (i = 0; i < str.length; i+=1) {
+        char = str.charCodeAt(i);
+         hash = ((hash<<5)-hash)+char;
+         hash = hash & hash; // Convert to 32bit integer
+     }
+     return hash;
+   }
+
+   /** Build the set of data we want to store about last view. */
+   this.buildViewData = function(issue) {
+      return {
+         number       : issue.number,
+         commentCount : issue.comments,
+         isPull       : !!issue.tr_pull_details,
+         pullComments : (issue.tr_pull_details ? issue.tr_pull_details.comments : null),
+         pullHead     : (issue.tr_pull_details ? issue.tr_pull_details.tr_head.sha : null),
+         bodyHash     : hashCode(issue.body),
+         titleHash    : hashCode(issue.title)
+      };
+   };
+
+   /**
+   * Return last viewed information
+   */
+   this.getLastViewedData = function(issue) {
+      return lastViewStore.get(issue.number);
+   };
+
+   /**
+   * Set last viewed time to now.
+   * @return Copy of the last view data record.
+   */
+   this.setLastViewedData = function(issue) {
+      var view_data = this.buildViewData(issue);
+      lastViewStore.save(view_data);
+      return view_data;
+   };
+
+})
+
+;


### PR DESCRIPTION
The use case is that when reviewing code you don't want to keep looking at it unless someone has changed it since the last time you went through it.

Idea 1:
- Store the last viewed time for every issue in local storage
- When showing an issue, style it based upon the last update time vs last viewed
- Update last viewed time when showing details or opening link about issue

This works very well and is fast, but has problem that it is tied to the local browser.  In my opinion this is a reasonable tradeoff.

Idea 2:

Same as above but track comment count.  This should work better and give more specific results.

You should look again when one of these changes:
- new comments
- new pull comment
- I was mentioned (no idea how to implement)
- change hash of head
- change in description
- change in title

<!-- TRESTLE
{"weight":0,"columnWeight":0,"milestoneWeight":-246}
-->
