### PR TITLE
Parse error when issue/pull has old huboard config lines

### DIFF
--- a/src/app/services/issue_helpers.js
+++ b/src/app/services/issue_helpers.js
@@ -165,8 +165,25 @@ angular.module('Trestle')
       var body = issue.body;
 
       var lines = _.map(body.split('\n'), function(line) {return line.trim();}),
-          conf_begin = _.findIndex(lines, function(line) {return line === config_header;}),
-          conf_end   = _.findIndex(lines, function(line) {return line === config_footer;});
+          conf_begin = -1, conf_end = -1;
+
+      function find_matching_line(offset, text) {
+         var idx = _.findIndex(_.tail(lines, offset), function(line) {
+             return line === text;
+          });
+         if (idx > -1) {
+            idx = idx + offset;
+         }
+         return idx;
+      }
+
+      // Figure out where the configuration block is
+      // - If, for some reason, there are more then one configuration blocks
+      //   this will only find the first one.
+      conf_begin = find_matching_line(0, config_header);
+      if (conf_begin > -1) {
+          conf_end = find_matching_line(conf_begin, config_footer);
+      }
 
       if (conf_begin > -1 && conf_end > -1) {
          var config_str = lines.slice(conf_begin+1, conf_end).join('\n');


### PR DESCRIPTION
If a pull has something like the following as it's body we get parse errors. This is because of the code in `issue_helpers.js` that tries to find the `conf_begin` and `conf_end`. Since `conf_end` is found before `conf_begin` we end up with an empty `config_str` which causes a JSON parse error. It appears that the end result is that we continue to add more config sections that in the end are not used.

```
"This is some pull with a discussion in it.

<!---
@huboard:{"order":8.0999323128772e-06}
-->

<!-- TRESTLE
{"columnWeight":-881.5,"milestoneWeight":-671}
-->
<!-- TRESTLE
{"columnWeight":-637,"milestoneWeight":210}
-->"
```

<!-- TRESTLE
{"columnWeight":4,"milestoneWeight":969}
-->

<!-- TRESTLE
{"columnWeight":-951.5,"milestoneWeight":674}
-->

<!-- TRESTLE
{"columnWeight":0,"milestoneWeight":384}
-->

<!-- TRESTLE
{"columnWeight":0,"milestoneWeight":-261}
-->
