### PR TITLE
Build Status wrong

### DIFF
--- a/src/app/services/issue_helpers.js
+++ b/src/app/services/issue_helpers.js
@@ -223,9 +223,10 @@ angular.module('Trestle')
                issue.tr_pull_details = pullResult;
 
                gh.getStatus(trRepoModel.owner, trRepoModel.repo, head_ref).then(
-                  function(statusResult) {
-                     issue.tr_build_status     = statusResult;
-                     issue.tr_top_build_status = statusResult[0];
+                  function(statusResults) {
+                     issue.tr_build_status     = statusResults;
+                     issue.tr_top_build_status = _.last(
+                        _.sortBy(statusResults, 'updated_at'));
                   }
                );
             }


### PR DESCRIPTION
The code that retrieves the build status: `issue_helpers.js` ~ line `228` uses the top status, however github either changed the order they return these in or we were always grabbing the wrong result.

The last entry in the list is the most recent currently.

Probably the best solution would be to select the one with the most recent timestamp.

<!-- TRESTLE
{"columnWeight":-539,"milestoneWeight":725}
-->
