### PR TITLE
Fix column width in Firefox

### DIFF
--- a/src/app/board/columns/issue_columns.scss
+++ b/src/app/board/columns/issue_columns.scss
@@ -40,7 +40,7 @@ $backlog-width: 19%;
   height          : 100%;
   padding-top     : 8px;
   padding-top     : $header-height + 8px;
-  box-sizing      : border-box;
+  @include box-sizing(border-box);
   @include transition(margin $animation-speed ease-in);
 
   // Columns
@@ -53,7 +53,7 @@ $backlog-width: 19%;
 // Text labels on the top of each column
 .column-header {
   position        : relative;
-  box-sizing      : border-box;
+  @include box-sizing(border-box);
   margin-top      : 0;
   margin-bottom   : 10px;
   padding         : 3px 4px 3px 7px;
@@ -85,7 +85,7 @@ $backlog-width: 19%;
 }
 
 .column {
-  box-sizing      : border-box;
+  @include box-sizing(border-box);
   min-height      : 100%;
   margin          : 0;
   padding         : 0 10px;
@@ -115,7 +115,7 @@ $backlog-width: 19%;
     left          : 0;
     top           : $header-height;
     bottom        : 0;
-    box-sizing    : border-box;
+    @include box-sizing(border-box);
     @include transition(left $animation-speed ease-in);
     z-index       : 1;
     width         : $backlog-width;

--- a/src/app/issue_filters/issue_filter.scss
+++ b/src/app/issue_filters/issue_filter.scss
@@ -25,7 +25,7 @@ $filter-width: 175px;   // width of the filter panel
     right         : 0;
     top           : $header-height - 1;
     bottom        : 0;
-    box-sizing    : border-box;
+    @include box-sizing(border-box);
     @include transition(right $animation-speed ease-in);
     z-index       : 1;
     width         : $filter-width;
@@ -80,7 +80,7 @@ $filter-width: 175px;   // width of the filter panel
     position        : absolute;
     top             : 0;
     left            : 0;
-    box-sizing      : border-box;
+    @include box-sizing(border-box);
     width           : 100%;
     height          : 100%;
     overflow-y      : auto;

--- a/src/app/toolbar/toolbar.scss
+++ b/src/app/toolbar/toolbar.scss
@@ -22,7 +22,7 @@
       .search-query {
         width           :      100%;
         padding         :    13px;
-        box-sizing      : border-box;
+        @include box-sizing(border-box);
       }
     }
 


### PR DESCRIPTION
It looks like part of the issue might be that we are using webkit specific scrollbar changes. (I looked, you can't do that in firefox.)

![screenshot from 2013-09-19 11 32 53](https://f.cloud.github.com/assets/1002908/1174540/3f453312-2149-11e3-99b4-1d63cf3a9178.png)

<!-- TRESTLE
{"columnWeight":0,"milestoneWeight":708}
-->
